### PR TITLE
rockspec + 5.2 fix

### DIFF
--- a/lightningmdb-0.9-1.rockspec
+++ b/lightningmdb-0.9-1.rockspec
@@ -1,7 +1,7 @@
 package = "Lightningmdb"
 version = "0.9-1"
 source = {
-   url = "git@github.com:shmul/lightningdbm.git"
+   url = "git://github.com/shmul/lightningdbm.git"
 }
 description = {
    summary = "A thin wrapper around OpenLDAP Lightning Memory-Mapped Database (LMDB).",

--- a/lightningmdb-0.9-1.rockspec
+++ b/lightningmdb-0.9-1.rockspec
@@ -14,6 +14,12 @@ description = {
 dependencies = {
    "lua >= 5.1"
 }
+external_dependencies = {
+  LMDB = {
+    header = "lmdb.h",
+    library = "lmdb",
+  }
+}
 build = {
    type = "builtin",
    modules = {
@@ -21,8 +27,8 @@ build = {
          sources = {"lightningmdb.c"},
          defines = {},
          libraries = {"lmdb"},
-         incdirs = {"$(LMDBINC)"},
-         libdirs = {"$(LMDBLIB)"}
+         incdirs = {"$(LMDB_INCDIR)"},
+         libdirs = {"$(LMDB_LIBDIR)"}
       }
    }
 }

--- a/lightningmdb.c
+++ b/lightningmdb.c
@@ -10,8 +10,6 @@
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
-#include "lpack.c"
-
 
 #if LUA_VERSION_NUM<=501
 typedef luaL_reg lua_reg_t;
@@ -33,6 +31,11 @@ int lua_type_error(lua_State *L,int narg,const char *tname) {
 }
 #endif
 
+#ifndef luaL_reg
+#define luaL_reg luaL_Reg
+#endif
+
+#include "lpack.c"
 
 #define LIGHTNING "lightningmdb"
 #define ENV "lightningmdb_env"


### PR DESCRIPTION
- small Lua 5.2 fix: lpack uses `luaL_reg` which is not in stock 5.2 (renamed to `luaL_Reg`).

- rockspec: use a Git URL everybody can pull from

- rockspec: correct use of  `external_dependencies` (see [here](http://luarocks.org/en/Rockspec_format)) Note: this required renaming the variables `LMDBINC` to `LMDB_INCDIR` and `LMDBLIB` to `LMDB_LIBDIR` to respect LuaRocks conventions.